### PR TITLE
Add VRCUrls to player at runtime

### DIFF
--- a/Runtime/Components/PredefinedUrlQueueAdder.cs
+++ b/Runtime/Components/PredefinedUrlQueueAdder.cs
@@ -1,0 +1,47 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+namespace Yamadev.YamaStream
+{
+    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+    public class PredefinedUrlQueueAdder : Listener
+    {
+        [Header("Player References")]
+        [SerializeField] Controller _controller;
+
+        [Header("Predefined URL (set in Inspector)")]
+        [SerializeField] VRCUrl _predefinedUrl = default;
+        [SerializeField] string _title = "";
+
+        [Header("Player Type")]
+        [SerializeField] bool _useCurrentPlayerType = true;
+        [SerializeField] VideoPlayerType _playerType = VideoPlayerType.AVProVideoPlayer;
+
+        [Header("Behavior")]
+        [SerializeField] bool _enqueueOnStart = false;
+
+        public void Start()
+        {
+            if (_controller != null) _controller.AddListener(this);
+            if (_enqueueOnStart) EnqueuePredefinedUrl();
+        }
+
+        public void EnqueuePredefinedUrl()
+        {
+            if (_controller == null) return;
+            if (!_predefinedUrl.IsValid()) return;
+
+            var resolvedPlayerType = _useCurrentPlayerType ? _controller.VideoPlayerType : _playerType;
+
+            _controller.Queue.TakeOwnership();
+            _controller.Queue.AddTrack(Track.New(resolvedPlayerType, _title == null ? string.Empty : _title, _predefinedUrl));
+        }
+
+        public void SetUrlAndEnqueue(VRCUrl url)
+        {
+            _predefinedUrl = url;
+            EnqueuePredefinedUrl();
+        }
+    }
+}


### PR DESCRIPTION
Add `PredefinedUrlQueueAdder` UdonSharp script to enqueue a build-time `VRCUrl` to the player's queue at runtime.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4cfdf2d-b93b-4ae7-9611-607f14aea6eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4cfdf2d-b93b-4ae7-9611-607f14aea6eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

