### PR TITLE
Add VRCUrls to player at runtime

### DIFF
--- a/Runtime/Components/README_QueueManager.md
+++ b/Runtime/Components/README_QueueManager.md
@@ -1,0 +1,154 @@
+# YamaPlayer Queue Manager
+
+YamaPlayerのイベントを利用してVRCUrlをランタイム中にキュートに追加するUdonSharpスクリプトです。
+
+## 概要
+
+このスクリプトは、YamaPlayerのプレイヤーイベント（動画終了、エラー、停止など）を利用して、事前に定義されたVRCUrlを自動的にキュートに追加する機能を提供します。
+
+## 含まれるスクリプト
+
+### 1. YamaPlayerQueueManager.cs
+基本的なキュート管理機能を提供するスクリプトです。
+
+**主な機能:**
+- 事前定義されたURLの自動追加
+- プレイヤーイベントに基づく自動キュート追加
+- キュートの手動管理
+- キュート情報の表示
+
+### 2. YamaPlayerDynamicQueueManager.cs
+高度なキュート管理機能を提供するスクリプトです。
+
+**主な機能:**
+- ランタイムでの動的URL追加
+- ネットワーク同期対応
+- シャッフル再生
+- ループ再生
+- 自動再生設定
+- キュート状態の定期チェック
+
+## セットアップ方法
+
+### 1. 基本的なセットアップ
+
+1. **YamaPlayerQueueManager**をGameObjectに追加
+2. **Controller**フィールドにYamaPlayerのControllerを割り当て
+3. 必要に応じて**Predefined URLs**にURLを設定
+4. **Use Predefined URLs**を有効にする
+
+### 2. 高度なセットアップ
+
+1. **YamaPlayerDynamicQueueManager**をGameObjectに追加
+2. **Controller**フィールドにYamaPlayerのControllerを割り当て
+3. 各種設定を調整
+
+## 設定項目
+
+### YamaPlayerQueueManager
+
+| 項目 | 説明 |
+|------|------|
+| Controller | YamaPlayerのControllerコンポーネント |
+| Auto Add To Queue | 自動キュート追加の有効/無効 |
+| Notify On Add | 追加時の通知表示 |
+| Predefined URLs | 事前定義されたURL配列 |
+| Use Predefined URLs | 事前定義URLの使用有効/無効 |
+| Add On Video End | 動画終了時の追加 |
+| Add On Video Error | 動画エラー時の追加 |
+| Add On Video Stop | 動画停止時の追加 |
+
+### YamaPlayerDynamicQueueManager
+
+| 項目 | 説明 |
+|------|------|
+| Controller | YamaPlayerのControllerコンポーネント |
+| Dynamic URLs | 動的URL配列（ネットワーク同期） |
+| Max Dynamic URLs | 最大動的URL数 |
+| Auto Play Next | 自動次曲再生 |
+| Loop Queue | キュートループ |
+| Shuffle Queue | シャッフル再生 |
+| Add On Video End | 動画終了時の追加 |
+| Add On Video Error | 動画エラー時の追加 |
+| Add On Video Stop | 動画停止時の追加 |
+| Enable Notifications | 通知表示 |
+| Queue Check Interval | キュートチェック間隔 |
+| Enable Queue Validation | キュート検証有効/無効 |
+
+## 使用方法
+
+### 基本的な使用方法
+
+1. **自動追加**: プレイヤーイベントに基づいて自動的にURLがキュートに追加されます
+2. **手動追加**: `AddUrlToQueue(VRCUrl url)`メソッドを使用して手動でURLを追加
+3. **キュート管理**: `ClearQueue()`、`ShowQueueInfo()`メソッドでキュートを管理
+
+### 高度な使用方法
+
+1. **動的URL追加**: `AddDynamicUrl(VRCUrl url)`でランタイム中にURLを追加
+2. **一括追加**: `AddDynamicUrls(VRCUrl[] urls)`で複数のURLを一括追加
+3. **URL削除**: `RemoveDynamicUrl(int index)`で特定のURLを削除
+4. **ランダム追加**: `AddRandomDynamicUrlToQueue()`でランダムにURLを追加
+
+## イベントハンドラー
+
+### 利用可能なイベント
+
+- `OnVideoEnd()`: 動画終了時
+- `OnVideoError(VideoError videoError)`: 動画エラー時
+- `OnVideoStop()`: 動画停止時
+- `OnQueueUpdated()`: キュート更新時
+- `OnTrackUpdated()`: トラック更新時
+
+### イベントのカスタマイズ
+
+各イベントハンドラーは、設定項目に基づいて動作します。必要に応じて、スクリプトを編集してカスタムロジックを追加できます。
+
+## 注意事項
+
+1. **ネットワーク同期**: YamaPlayerDynamicQueueManagerは`BehaviourSyncMode.Manual`を使用しているため、URLの追加/削除はオーナーのみが実行できます
+2. **URL検証**: 追加されるURLは自動的に検証されます
+3. **パフォーマンス**: 大量のURLを追加する場合は、`Max Dynamic URLs`を適切に設定してください
+4. **エラーハンドリング**: 無効なURLは自動的にスキップされ、エラーログに記録されます
+
+## サンプルコード
+
+### 基本的なURL追加
+```csharp
+// YamaPlayerQueueManagerのインスタンスを取得
+YamaPlayerQueueManager queueManager = GetComponent<YamaPlayerQueueManager>();
+
+// URLを追加
+VRCUrl url = new VRCUrl("https://example.com/video.mp4");
+queueManager.AddUrlToQueue(url);
+```
+
+### 動的URL追加
+```csharp
+// YamaPlayerDynamicQueueManagerのインスタンスを取得
+YamaPlayerDynamicQueueManager dynamicQueueManager = GetComponent<YamaPlayerDynamicQueueManager>();
+
+// 動的URLを追加
+VRCUrl url = new VRCUrl("https://example.com/video.mp4");
+dynamicQueueManager.AddDynamicUrl(url);
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+1. **Controllerが割り当てられていない**
+   - エラー: "Controller is not assigned!"
+   - 解決: ControllerフィールドにYamaPlayerのControllerを割り当ててください
+
+2. **URLが追加されない**
+   - 原因: 無効なURLまたはネットワーク権限の問題
+   - 解決: URLの形式を確認し、オーナー権限があることを確認してください
+
+3. **イベントが発火しない**
+   - 原因: Controllerにリスナーとして登録されていない
+   - 解決: Start()メソッドで`_controller.AddListener(this)`が実行されていることを確認してください
+
+## ライセンス
+
+このスクリプトはYamaPlayerプロジェクトの一部として提供されています。

--- a/Runtime/Components/YamaPlayerDynamicQueueManager.cs
+++ b/Runtime/Components/YamaPlayerDynamicQueueManager.cs
@@ -1,0 +1,437 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+using VRC.SDK3.Components.Video;
+using System;
+
+namespace Yamadev.YamaStream
+{
+    [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+    public class YamaPlayerDynamicQueueManager : UdonSharpBehaviour
+    {
+        [Header("YamaPlayer Controller")]
+        [SerializeField] Controller _controller;
+        
+        [Header("Dynamic URL Management")]
+        [SerializeField, UdonSynced] VRCUrl[] _dynamicUrls = new VRCUrl[] { };
+        [SerializeField] int _maxDynamicUrls = 50;
+        
+        [Header("Queue Behavior")]
+        [SerializeField] bool _autoPlayNext = true;
+        [SerializeField] bool _loopQueue = false;
+        [SerializeField] bool _shuffleQueue = false;
+        
+        [Header("Event Settings")]
+        [SerializeField] bool _addOnVideoEnd = true;
+        [SerializeField] bool _addOnVideoError = true;
+        [SerializeField] bool _addOnVideoStop = false;
+        [SerializeField] bool _enableNotifications = true;
+        
+        [Header("Advanced Settings")]
+        [SerializeField] float _queueCheckInterval = 1.0f;
+        [SerializeField] bool _enableQueueValidation = true;
+        
+        private int _currentDynamicIndex = 0;
+        private bool _isInitialized = false;
+        private float _lastQueueCheck = 0f;
+        private System.Random _random;
+        
+        void Start()
+        {
+            if (_controller == null)
+            {
+                Debug.LogError("[YamaPlayerDynamicQueueManager] Controller is not assigned!");
+                return;
+            }
+            
+            _controller.AddListener(this);
+            _random = new System.Random();
+            _isInitialized = true;
+            
+            PrintLog("YamaPlayerDynamicQueueManager initialized successfully.");
+        }
+        
+        void Update()
+        {
+            if (!_isInitialized || _controller == null) return;
+            
+            // 定期的にキュートの状態をチェック
+            if (Time.time - _lastQueueCheck > _queueCheckInterval)
+            {
+                CheckQueueStatus();
+                _lastQueueCheck = Time.time;
+            }
+        }
+        
+        #region Public Methods - URL Management
+        
+        /// <summary>
+        /// 動的URLを追加
+        /// </summary>
+        /// <param name="url">追加するVRCUrl</param>
+        public void AddDynamicUrl(VRCUrl url)
+        {
+            if (!_isInitialized || !Networking.IsOwner(gameObject)) return;
+            
+            if (url.Get().IsValidUrl())
+            {
+                if (_dynamicUrls.Length < _maxDynamicUrls)
+                {
+                    _dynamicUrls = _dynamicUrls.Add(url);
+                    RequestSerialization();
+                    
+                    if (_enableNotifications)
+                    {
+                        PrintLog($"Added dynamic URL: {url.Get()}");
+                    }
+                }
+                else
+                {
+                    PrintError($"Maximum dynamic URLs reached ({_maxDynamicUrls})");
+                }
+            }
+            else
+            {
+                PrintError($"Invalid URL: {url.Get()}");
+            }
+        }
+        
+        /// <summary>
+        /// 複数の動的URLを一括追加
+        /// </summary>
+        /// <param name="urls">追加するVRCUrl配列</param>
+        public void AddDynamicUrls(VRCUrl[] urls)
+        {
+            if (!_isInitialized || !Networking.IsOwner(gameObject)) return;
+            
+            foreach (VRCUrl url in urls)
+            {
+                AddDynamicUrl(url);
+            }
+        }
+        
+        /// <summary>
+        /// 動的URLを削除
+        /// </summary>
+        /// <param name="index">削除するインデックス</param>
+        public void RemoveDynamicUrl(int index)
+        {
+            if (!_isInitialized || !Networking.IsOwner(gameObject)) return;
+            
+            if (index >= 0 && index < _dynamicUrls.Length)
+            {
+                VRCUrl removedUrl = _dynamicUrls[index];
+                _dynamicUrls = _dynamicUrls.RemoveAt(index);
+                RequestSerialization();
+                
+                if (_enableNotifications)
+                {
+                    PrintLog($"Removed dynamic URL: {removedUrl.Get()}");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// 動的URLをクリア
+        /// </summary>
+        public void ClearDynamicUrls()
+        {
+            if (!_isInitialized || !Networking.IsOwner(gameObject)) return;
+            
+            _dynamicUrls = new VRCUrl[] { };
+            _currentDynamicIndex = 0;
+            RequestSerialization();
+            
+            if (_enableNotifications)
+            {
+                PrintLog("All dynamic URLs cleared.");
+            }
+        }
+        
+        #endregion
+        
+        #region Public Methods - Queue Management
+        
+        /// <summary>
+        /// 動的URLをキュートに追加
+        /// </summary>
+        public void AddDynamicUrlToQueue()
+        {
+            if (!_isInitialized || _controller == null || _dynamicUrls.Length == 0) return;
+            
+            if (_currentDynamicIndex < _dynamicUrls.Length)
+            {
+                VRCUrl url = _dynamicUrls[_currentDynamicIndex];
+                AddUrlToQueue(url);
+                _currentDynamicIndex++;
+            }
+            else if (_loopQueue)
+            {
+                _currentDynamicIndex = 0;
+                if (_dynamicUrls.Length > 0)
+                {
+                    VRCUrl url = _dynamicUrls[_currentDynamicIndex];
+                    AddUrlToQueue(url);
+                    _currentDynamicIndex++;
+                }
+            }
+        }
+        
+        /// <summary>
+        /// ランダムな動的URLをキュートに追加
+        /// </summary>
+        public void AddRandomDynamicUrlToQueue()
+        {
+            if (!_isInitialized || _controller == null || _dynamicUrls.Length == 0) return;
+            
+            int randomIndex = _random.Next(0, _dynamicUrls.Length);
+            VRCUrl url = _dynamicUrls[randomIndex];
+            AddUrlToQueue(url);
+        }
+        
+        /// <summary>
+        /// URLをキュートに追加
+        /// </summary>
+        /// <param name="url">追加するVRCUrl</param>
+        public void AddUrlToQueue(VRCUrl url)
+        {
+            if (!_isInitialized || _controller == null) return;
+            
+            if (url.Get().IsValidUrl())
+            {
+                Track newTrack = Track.New(VideoPlayerType.AVProVideoPlayer, "", url);
+                _controller.Queue.AddTrack(newTrack);
+                
+                if (_enableNotifications)
+                {
+                    PrintLog($"Added URL to queue: {url.Get()}");
+                }
+            }
+            else
+            {
+                PrintError($"Invalid URL: {url.Get()}");
+            }
+        }
+        
+        /// <summary>
+        /// キュートをクリア
+        /// </summary>
+        public void ClearQueue()
+        {
+            if (!_isInitialized || _controller == null) return;
+            
+            _controller.Queue.Clear();
+            
+            if (_enableNotifications)
+            {
+                PrintLog("Queue cleared.");
+            }
+        }
+        
+        /// <summary>
+        /// キュートの情報を表示
+        /// </summary>
+        public void ShowQueueInfo()
+        {
+            if (!_isInitialized || _controller == null) return;
+            
+            int queueLength = _controller.Queue.Length;
+            PrintLog($"Queue contains {queueLength} tracks.");
+            
+            for (int i = 0; i < queueLength; i++)
+            {
+                Track track = _controller.Queue.GetTrack(i);
+                string title = track.HasTitle() ? track.GetTitle() : "No Title";
+                string url = track.GetUrl();
+                PrintLog($"  [{i}] {title} - {url}");
+            }
+        }
+        
+        /// <summary>
+        /// 動的URLの情報を表示
+        /// </summary>
+        public void ShowDynamicUrlsInfo()
+        {
+            if (!_isInitialized) return;
+            
+            PrintLog($"Dynamic URLs ({_dynamicUrls.Length}/{_maxDynamicUrls}):");
+            for (int i = 0; i < _dynamicUrls.Length; i++)
+            {
+                string url = _dynamicUrls[i].Get();
+                string status = i == _currentDynamicIndex ? " [Current]" : "";
+                PrintLog($"  [{i}]{status} {url}");
+            }
+        }
+        
+        #endregion
+        
+        #region Public Methods - Settings
+        
+        /// <summary>
+        /// 自動再生設定を変更
+        /// </summary>
+        /// <param name="enabled">有効にするかどうか</param>
+        public void SetAutoPlayNext(bool enabled)
+        {
+            _autoPlayNext = enabled;
+            PrintLog($"Auto play next: {_autoPlayNext}");
+        }
+        
+        /// <summary>
+        /// ループ設定を変更
+        /// </summary>
+        /// <param name="enabled">有効にするかどうか</param>
+        public void SetLoopQueue(bool enabled)
+        {
+            _loopQueue = enabled;
+            PrintLog($"Loop queue: {_loopQueue}");
+        }
+        
+        /// <summary>
+        /// シャッフル設定を変更
+        /// </summary>
+        /// <param name="enabled">有効にするかどうか</param>
+        public void SetShuffleQueue(bool enabled)
+        {
+            _shuffleQueue = enabled;
+            PrintLog($"Shuffle queue: {_shuffleQueue}");
+        }
+        
+        #endregion
+        
+        #region YamaPlayer Event Handlers
+        
+        /// <summary>
+        /// 動画終了時のイベント
+        /// </summary>
+        public override void OnVideoEnd()
+        {
+            if (_addOnVideoEnd)
+            {
+                if (_shuffleQueue)
+                {
+                    AddRandomDynamicUrlToQueue();
+                }
+                else
+                {
+                    AddDynamicUrlToQueue();
+                }
+                
+                if (_autoPlayNext && _controller.Queue.Length > 0)
+                {
+                    _controller.Forward();
+                }
+            }
+        }
+        
+        /// <summary>
+        /// 動画エラー時のイベント
+        /// </summary>
+        /// <param name="videoError">エラー情報</param>
+        public override void OnVideoError(VideoError videoError)
+        {
+            if (_addOnVideoError)
+            {
+                PrintLog($"Video error occurred: {videoError}. Adding next URL to queue.");
+                
+                if (_shuffleQueue)
+                {
+                    AddRandomDynamicUrlToQueue();
+                }
+                else
+                {
+                    AddDynamicUrlToQueue();
+                }
+            }
+        }
+        
+        /// <summary>
+        /// 動画停止時のイベント
+        /// </summary>
+        public override void OnVideoStop()
+        {
+            if (_addOnVideoStop)
+            {
+                if (_shuffleQueue)
+                {
+                    AddRandomDynamicUrlToQueue();
+                }
+                else
+                {
+                    AddDynamicUrlToQueue();
+                }
+            }
+        }
+        
+        /// <summary>
+        /// キュート更新時のイベント
+        /// </summary>
+        public override void OnQueueUpdated()
+        {
+            if (_enableNotifications)
+            {
+                PrintLog("Queue updated.");
+            }
+        }
+        
+        /// <summary>
+        /// トラック更新時のイベント
+        /// </summary>
+        public override void OnTrackUpdated()
+        {
+            if (_enableNotifications)
+            {
+                Track currentTrack = _controller.Track;
+                if (currentTrack.HasTitle())
+                {
+                    PrintLog($"Now playing: {currentTrack.GetTitle()}");
+                }
+            }
+        }
+        
+        #endregion
+        
+        #region Private Methods
+        
+        /// <summary>
+        /// キュートの状態をチェック
+        /// </summary>
+        private void CheckQueueStatus()
+        {
+            if (!_enableQueueValidation || _controller == null) return;
+            
+            // キュートが空で、動的URLがある場合は追加
+            if (_controller.Queue.Length == 0 && _dynamicUrls.Length > 0)
+            {
+                if (_shuffleQueue)
+                {
+                    AddRandomDynamicUrlToQueue();
+                }
+                else
+                {
+                    AddDynamicUrlToQueue();
+                }
+            }
+        }
+        
+        /// <summary>
+        /// ログ出力
+        /// </summary>
+        /// <param name="message">メッセージ</param>
+        private void PrintLog(object message)
+        {
+            Debug.Log($"[<color=#EF6291>YamaPlayerDynamicQueueManager</color>] {message}");
+        }
+        
+        /// <summary>
+        /// エラーログ出力
+        /// </summary>
+        /// <param name="message">エラーメッセージ</param>
+        private void PrintError(object message)
+        {
+            Debug.LogError($"[<color=#EF6291>YamaPlayerDynamicQueueManager</color>] {message}");
+        }
+        
+        #endregion
+    }
+}

--- a/Runtime/Components/YamaPlayerQueueManager.cs
+++ b/Runtime/Components/YamaPlayerQueueManager.cs
@@ -1,0 +1,225 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+using VRC.SDK3.Components.Video;
+
+namespace Yamadev.YamaStream
+{
+    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+    public class YamaPlayerQueueManager : UdonSharpBehaviour
+    {
+        [Header("YamaPlayer Controller")]
+        [SerializeField] Controller _controller;
+        
+        [Header("Queue Management")]
+        [SerializeField] bool _autoAddToQueue = true;
+        [SerializeField] bool _notifyOnAdd = true;
+        
+        [Header("URL Management")]
+        [SerializeField] VRCUrl[] _predefinedUrls = new VRCUrl[] { };
+        [SerializeField] bool _usePredefinedUrls = false;
+        
+        [Header("Event Triggers")]
+        [SerializeField] bool _addOnVideoEnd = true;
+        [SerializeField] bool _addOnVideoError = false;
+        [SerializeField] bool _addOnVideoStop = false;
+        
+        private int _currentUrlIndex = 0;
+        private bool _isInitialized = false;
+        
+        void Start()
+        {
+            if (_controller == null)
+            {
+                Debug.LogError("[YamaPlayerQueueManager] Controller is not assigned!");
+                return;
+            }
+            
+            // コントローラーにリスナーとして登録
+            _controller.AddListener(this);
+            _isInitialized = true;
+            
+            PrintLog("YamaPlayerQueueManager initialized successfully.");
+        }
+        
+        #region Public Methods
+        
+        /// <summary>
+        /// 手動でURLをキュートに追加
+        /// </summary>
+        /// <param name="url">追加するVRCUrl</param>
+        public void AddUrlToQueue(VRCUrl url)
+        {
+            if (!_isInitialized || _controller == null) return;
+            
+            if (url.Get().IsValidUrl())
+            {
+                Track newTrack = Track.New(VideoPlayerType.AVProVideoPlayer, "", url);
+                _controller.Queue.AddTrack(newTrack);
+                
+                if (_notifyOnAdd)
+                {
+                    PrintLog($"Added URL to queue: {url.Get()}");
+                }
+            }
+            else
+            {
+                PrintError($"Invalid URL: {url.Get()}");
+            }
+        }
+        
+        /// <summary>
+        /// 事前定義されたURLをキュートに追加
+        /// </summary>
+        public void AddPredefinedUrlToQueue()
+        {
+            if (!_usePredefinedUrls || _predefinedUrls.Length == 0) return;
+            
+            if (_currentUrlIndex < _predefinedUrls.Length)
+            {
+                AddUrlToQueue(_predefinedUrls[_currentUrlIndex]);
+                _currentUrlIndex++;
+            }
+            else
+            {
+                // すべてのURLを追加したら最初から再開
+                _currentUrlIndex = 0;
+                if (_predefinedUrls.Length > 0)
+                {
+                    AddUrlToQueue(_predefinedUrls[_currentUrlIndex]);
+                    _currentUrlIndex++;
+                }
+            }
+        }
+        
+        /// <summary>
+        /// キュートをクリア
+        /// </summary>
+        public void ClearQueue()
+        {
+            if (!_isInitialized || _controller == null) return;
+            
+            _controller.Queue.Clear();
+            PrintLog("Queue cleared.");
+        }
+        
+        /// <summary>
+        /// キュートの内容を表示
+        /// </summary>
+        public void ShowQueueInfo()
+        {
+            if (!_isInitialized || _controller == null) return;
+            
+            int queueLength = _controller.Queue.Length;
+            PrintLog($"Queue contains {queueLength} tracks.");
+            
+            for (int i = 0; i < queueLength; i++)
+            {
+                Track track = _controller.Queue.GetTrack(i);
+                string title = track.HasTitle() ? track.GetTitle() : "No Title";
+                string url = track.GetUrl();
+                PrintLog($"  [{i}] {title} - {url}");
+            }
+        }
+        
+        /// <summary>
+        /// 自動追加機能の切り替え
+        /// </summary>
+        /// <param name="enabled">有効にするかどうか</param>
+        public void SetAutoAddToQueue(bool enabled)
+        {
+            _autoAddToQueue = enabled;
+            PrintLog($"Auto add to queue: {_autoAddToQueue}");
+        }
+        
+        #endregion
+        
+        #region YamaPlayer Event Handlers
+        
+        /// <summary>
+        /// 動画終了時のイベント
+        /// </summary>
+        public override void OnVideoEnd()
+        {
+            if (_addOnVideoEnd && _autoAddToQueue)
+            {
+                AddPredefinedUrlToQueue();
+            }
+        }
+        
+        /// <summary>
+        /// 動画エラー時のイベント
+        /// </summary>
+        /// <param name="videoError">エラー情報</param>
+        public override void OnVideoError(VideoError videoError)
+        {
+            if (_addOnVideoError && _autoAddToQueue)
+            {
+                PrintLog($"Video error occurred: {videoError}. Adding next URL to queue.");
+                AddPredefinedUrlToQueue();
+            }
+        }
+        
+        /// <summary>
+        /// 動画停止時のイベント
+        /// </summary>
+        public override void OnVideoStop()
+        {
+            if (_addOnVideoStop && _autoAddToQueue)
+            {
+                AddPredefinedUrlToQueue();
+            }
+        }
+        
+        /// <summary>
+        /// キュート更新時のイベント
+        /// </summary>
+        public override void OnQueueUpdated()
+        {
+            if (_notifyOnAdd)
+            {
+                PrintLog("Queue updated.");
+            }
+        }
+        
+        /// <summary>
+        /// トラック更新時のイベント
+        /// </summary>
+        public override void OnTrackUpdated()
+        {
+            // トラックが更新された時の処理
+            if (_notifyOnAdd)
+            {
+                Track currentTrack = _controller.Track;
+                if (currentTrack.HasTitle())
+                {
+                    PrintLog($"Now playing: {currentTrack.GetTitle()}");
+                }
+            }
+        }
+        
+        #endregion
+        
+        #region Utility Methods
+        
+        /// <summary>
+        /// ログ出力
+        /// </summary>
+        /// <param name="message">メッセージ</param>
+        private void PrintLog(object message)
+        {
+            Debug.Log($"[<color=#EF6291>YamaPlayerQueueManager</color>] {message}");
+        }
+        
+        /// <summary>
+        /// エラーログ出力
+        /// </summary>
+        /// <param name="message">エラーメッセージ</param>
+        private void PrintError(object message)
+        {
+            Debug.LogError($"[<color=#EF6291>YamaPlayerQueueManager</color>] {message}");
+        }
+        
+        #endregion
+    }
+}


### PR DESCRIPTION
Add UdonSharp scripts to manage and queue VRCUrls using YamaPlayer events, supporting both predefined and runtime-added URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cd4ef06-794c-45fe-984b-0407381c541f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3cd4ef06-794c-45fe-984b-0407381c541f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

